### PR TITLE
fix: computing days in getDaysDuration

### DIFF
--- a/packages/fantasion-web/components/dates.js
+++ b/packages/fantasion-web/components/dates.js
@@ -33,4 +33,4 @@ export const DateRange = ({ start, end }) => {
 }
 
 export const getDaysDuration = (startsAt, endsAt) =>
-  Math.max((new Date(endsAt) - new Date(startsAt)) / 1000 / 60 / 60 / 24 - 1, 1)
+  Math.max((new Date(endsAt) - new Date(startsAt)) / 1000 / 60 / 60 / 24 + 1, 1)


### PR DESCRIPTION
For the autumn holidays it is necessary to calculate the length of the troops accurately. For example, if the troop lasts from the 24th to the 25th, the length is 2 days.